### PR TITLE
Fixed RD* / WR* carry flag behavior

### DIFF
--- a/pasmsim.c
+++ b/pasmsim.c
@@ -169,6 +169,7 @@ int32_t ExecutePasmInstruction(PasmVarsT *pasmvars)
 		else
 		    LONG(value2) = pasmvars->mem[dstaddr];
 	    }
+        cflag = 0;
 	    break;
 
 	    case 3: // misc hubops


### PR DESCRIPTION
Hi there, first of all, thanks to all of you for your great work!

Guess I found a little bug regarding the C-Flags of RD* and WR* instructions that I'm eager to fix. The Manual v1.2 does not explicitly mention carry flags for these instructions, but it occurs in the concise truth tables as 0. I wrote a small PASM program to verify that and indeed, the carry flag gets unset by these instructions. You can observe the behavior by (un)commenting either the CMP or the rd/wrbyte.

The pull request sets ```C=false``` for the following instructuions:
```RDBYTE, WRBYTE, RDWORD, WRWORD, RDLONG, WRLONG```

Best wishes!

```
Program
                jmp #:rd
                ' jmp #:wr

:rd             cmp      a, b        WC         ' Sets C 
                rdbyte   v, PAR      WC         ' Sets C=false

       if_c     wrlong   a, PAR                 ' 
       if_nc    wrlong   b, PAR                 ' <- C is unset by rdbyte
                jmp      #:end

:wr             cmp      a, b        WC         ' Sets C 
                wrbyte   some, PAR   WC         ' Sets C=false

       if_c     wrlong   a, PAR                 ' 
       if_nc    wrlong   b, PAR                 ' <- C is unset by wrbyte

:end
                a        LONG  7
                b        LONG  13
                some     LONG  2
                v        RES   1
                fit      496

```